### PR TITLE
feat: add `display_name` to autodoc()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## v4.1.0 - 2026-03-09
+- Added `display_name` keyword argument to `autodoc()`
+- Fixed `autodoc()` members not respecting `LowerCaseMixin` and `TitleCaseMixin`
+
+
 ## v4.0.0 - 2026-02-10
 - Added `autodoc()` functionality
 - Dropped support for Python 3.9

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ For more information on enums (and the auto method), see [the official docs]
 
 ## Mixins
 
-There are two mixins provided that change the behavior of `auto()`:
+There are two mixins provided that change the case of member values for both `auto()` and `autodoc()`:
 
-- `LowerCaseMixin`: values produced by `auto()` are in all lower-case
-- `TitleCaseMixin`: values produced by `auto()` will be in title- case (lower-case except for first letter)
+- `LowerCaseMixin`: values are in all lower-case
+- `TitleCaseMixin`: values are in title-case (lower-case except for first letter)
 
 When these mixins are used, they _must_ be included after `AutoNameEnum` in the class inheritance declaration:
 
@@ -65,8 +65,9 @@ class Aliens(AutoNameEnum, TitleCaseMixin)
 
 ## Documented members with `autodoc()`
 
-The `autodoc()` function works like `auto()`, but also attaches a description to each enum member.
-This is useful for self-documenting enums where members need human-readable explanations:
+The `autodoc()` function works like `auto()`, but also attaches a `description` and/or
+`display_name` to each enum member. This is useful for self-documenting enums where members
+need human-readable explanations or labels:
 
 ```python
 class Aliens(AutoNameEnum):
@@ -90,8 +91,21 @@ Access the description via the `.description` property:
 'A small, rodent-like alien from Tatooine'
 ```
 
+A `display_name` can also be attached as a keyword argument:
+
+```python
+class Aliens(AutoNameEnum):
+    JAWA = autodoc(description="A small, rodent-like alien from Tatooine", display_name="Jawa (Tatooine)")
+    EWOK = autodoc(description="A furry, diminutive alien from the forest moon of Endor", display_name="Ewok (Endor)")
+```
+
+```
+>>> print(Aliens.JAWA.display_name)
+'Jawa (Tatooine)'
+```
+
 You can mix `auto()` and `autodoc()` in the same enum. Members created with `auto()` will return
-`None` for `.description`:
+`None` for `.description` and their value for `.display_name`:
 
 ```python
 class Aliens(AutoNameEnum):
@@ -105,4 +119,6 @@ class Aliens(AutoNameEnum):
 'A small, rodent-like alien from Tatooine'
 >>> print(Aliens.EWOK.description)
 None
+>>> print(Aliens.EWOK.display_name)
+'EWOK'
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auto-name-enum"
-version = "4.0.0"
+version = "4.1.0"
 description = "String-based Enum class that automatically assigns values"
 authors = [
     {name = "Tucker Beck", email ="tucker.beck@gmail.com"},

--- a/src/auto_name_enum/base.py
+++ b/src/auto_name_enum/base.py
@@ -1,3 +1,4 @@
+from IPython.display import display
 import enum
 import random
 import sys
@@ -14,8 +15,9 @@ auto = enum.auto
 class _AutodocValue:
     """Sentinel wrapper that carries a description alongside an enum member assignment."""
 
-    def __init__(self, description: str) -> None:
+    def __init__(self, description: str | None = None, display_name: str | None = None) -> None:
         self.description = description
+        self.display_name = display_name
 
 
 class _EnumDictProxy:
@@ -25,16 +27,37 @@ class _EnumDictProxy:
     When an _AutodocValue is assigned to a member name, the proxy extracts the description
     and replaces the value with the member name (mimicking auto-naming behavior). All other
     attribute access is delegated to the underlying EnumDict via __getattr__.
+
+    Note:
+        The MRO must be walked in reverse order so that mixins can be specified after the
+        base AutoNameEnum class.
     """
 
-    def __init__(self, enum_dict: Any) -> None:
+    def __init__(self, enum_dict: Any, bases: tuple[type, ...]) -> None:
         object.__setattr__(self, "_enum_dict", enum_dict)
         object.__setattr__(self, "_descriptions", {})
+        object.__setattr__(self, "_display_names", {})
+        generate = next(
+            (
+                cls.__dict__["_generate_next_value_"]
+                for base in reversed(bases)
+                for cls in base.__mro__
+                if "_generate_next_value_" in cls.__dict__
+            ),
+            None,
+        )
+        object.__setattr__(self, "_generate_next_value_", generate)
 
     def __setitem__(self, key: str, value: Any) -> None:
         if isinstance(value, _AutodocValue):
-            self._descriptions[key] = value.description
-            self._enum_dict[key] = key
+            transformed = key
+            if self._generate_next_value_ is not None:
+                transformed = self._generate_next_value_(key, 1, 0, [])
+            self._enum_dict[key] = transformed
+            if value.description:
+                self._descriptions[key] = value.description
+            if value.display_name:
+                self._display_names[key] = value.display_name
         else:
             self._enum_dict[key] = value
 
@@ -48,24 +71,16 @@ class _EnumDictProxy:
         return getattr(self._enum_dict, name)
 
 
-def autodoc(description: str) -> Any:
+
+def autodoc(description: str | None = None, display_name: str | None = None) -> Any:
     """
-    Like auto(), but allows attaching a description to the enum member.
+    Like auto(), but allows attaching a description and/or display name to the enum member.
 
-    The description can be accessed via the .description property on the enum member.
+    These can be accessed via the .description and .display_name property on the enum member.
 
-    Example:
-        class Aliens(AutoNameEnum):
-            JAWA = autodoc("A small, rodent-like alien from Tatooine")
-            EWOK = autodoc("A furry, diminutive alien from the forest moon of Endor")
-            HUTT = autodoc("A large, slug-like alien from Nal Hutta")
-
-        >> print(Aliens.JAWA.value)
-        'JAWA'
-        >> print(Aliens.JAWA.description)
-        'A small, rodent-like alien from Tatooine'
+    For usage examples, see AutoNameEnum
     """
-    return _AutodocValue(description)
+    return _AutodocValue(description=description, display_name=display_name)
 
 
 class AutoNameEnumMeta(enum.EnumMeta):
@@ -75,20 +90,23 @@ class AutoNameEnumMeta(enum.EnumMeta):
         mcs, name: str, bases: tuple[type, ...], **kwds: Any
     ) -> Any:  # ty: ignore[invalid-method-override]  -- returns _EnumDictProxy instead of _EnumDict; intentional to intercept autodoc assignments
         ed = super().__prepare__(name, bases, **kwds)
-        return _EnumDictProxy(ed)
+        return _EnumDictProxy(ed, bases)
 
     @override
     def __new__(mcs, name: str, bases: tuple[type, ...], namespace: Any, **kwds: Any) -> "AutoNameEnumMeta":
-        # Extract descriptions from our proxy before passing the real EnumDict to super
+        # Extract docs from our proxy before passing the real EnumDict to super
         if isinstance(namespace, _EnumDictProxy):
-            descriptions: dict[str, str] = namespace._descriptions
+            descriptions: dict[str, str | None] = namespace._descriptions
+            display_names: dict[str, str | None] = namespace._display_names
             real_ns = namespace._enum_dict
         else:
             descriptions = {}
+            display_names = {}
             real_ns = namespace
 
         cls = super().__new__(mcs, name, bases, real_ns, **kwds)
         cls._descriptions = descriptions  # type: ignore[attr-defined]  -- dynamically attaching _descriptions dict to the class; not declared in type stubs
+        cls._display_names = display_names  # type: ignore[attr-defined]  -- dynamically attaching _display_names dict to the class; not declared in type stubs
         return cls
 
     @override
@@ -114,16 +132,28 @@ class AutoNameEnum(str, enum.Enum, metaclass=AutoNameEnumMeta):
         >> print(Aliens.JAWA)
         'JAWA'
 
-    Members can also be created with autodoc() to attach a description:
+    Members can also be created with autodoc() to attach a description and/or display_name:
 
+    Example:
         class Aliens(AutoNameEnum):
             JAWA = autodoc("A small, rodent-like alien from Tatooine")
-            EWOK = autodoc("A furry, diminutive alien from the forest moon of Endor")
+            EWOK = autodoc(display_name="Ewok")
+            HUTT = autodoc(description="A large, slug-like alien from Nal Hutta", display_name="The Almighty Hutt")
 
         >> print(Aliens.JAWA.value)
         'JAWA'
         >> print(Aliens.JAWA.description)
         'A small, rodent-like alien from Tatooine'
+        >> print(Aliens.JAWA.display_name)
+        'JAWA'
+        >> print(Aliens.Ewok.display_name)
+        'Ewok'
+        >> print(Aliens.EWOK.description)
+        None
+        >> print(Aliens.HUTT.description)
+        'A large, slug-like alien from Nal Hutta'
+        >> print(Aliens.HUTT.display_name)
+        'The Almighty Hutt'
 
     Note:
         This class inherits from str as well as Enum so that it will be properly
@@ -146,6 +176,13 @@ class AutoNameEnum(str, enum.Enum, metaclass=AutoNameEnumMeta):
         if hasattr(self.__class__, "_descriptions"):
             return self.__class__._descriptions.get(self.name)  # type: ignore[attr-defined]  -- _descriptions is dynamically attached by the metaclass __new__
         return None
+
+    @property
+    def display_name(self) -> str | None:
+        """Return the display_name if this member was created with autodoc()."""
+        if hasattr(self.__class__, "_display_names"):
+            return self.__class__._display_names.get(self.name, self.value)  # type: ignore[attr-defined]  -- _display_names is dynamically attached by the metaclass __new__
+        return self.value
 
     @classmethod
     def rando(cls) -> Self:

--- a/src/auto_name_enum/base.py
+++ b/src/auto_name_enum/base.py
@@ -1,4 +1,3 @@
-from IPython.display import display
 import enum
 import random
 import sys

--- a/tests/test_auto_name_enum.py
+++ b/tests/test_auto_name_enum.py
@@ -12,19 +12,6 @@ class DummyEnum(AutoNameEnum):
     HUTT = auto()
 
 
-class DocEnum(AutoNameEnum):
-    JAWA = autodoc("A small, rodent-like alien from Tatooine")
-    EWOK = autodoc("A furry, diminutive alien from the forest moon of Endor")
-    HUTT = autodoc("A large, slug-like alien from Nal Hutta")
-    PYKE = autodoc("A secretive, spice-dealing alien from Oba Diah")
-
-
-class MixedEnum(AutoNameEnum):
-    JAWA = autodoc("A small, rodent-like alien from Tatooine")
-    EWOK = auto()
-    HUTT = autodoc("A large, slug-like alien from Nal Hutta")
-
-
 class TestAutoNameEnum:
     def test_auto(self):
         """
@@ -99,33 +86,68 @@ class TestAutoNameEnum:
             assert 1 not in DummyEnum
 
 
+class PositionalDescriptionEnum(AutoNameEnum):
+    JAWA = autodoc("A small, rodent-like alien from Tatooine")
+    EWOK = autodoc("A furry, diminutive alien from the forest moon of Endor")
+    HUTT = autodoc("A large, slug-like alien from Nal Hutta")
+    PYKE = autodoc("A secretive, spice-dealing alien from Oba Diah")
+
+
+class KwargDocsEnum(AutoNameEnum):
+    JAWA = autodoc(description="A small, rodent-like alien from Tatooine", display_name="Jawa (Tatooine)")
+    EWOK = autodoc(description="A furry, diminutive alien from the forest moon of Endor", display_name="Ewok (Endor)")
+    HUTT = autodoc(description="A large, slug-like alien from Nal Hutta", display_name="Hutt (Nal Hutta)")
+    PYKE = autodoc(description="A secretive, spice-dealing alien from Oba Diah", display_name="Pyke (Oba Diah)")
+
+
+class MixedEnum(AutoNameEnum):
+    JAWA = autodoc("A small, rodent-like alien from Tatooine")
+    EWOK = auto()
+    HUTT = autodoc(description="A large, slug-like alien from Nal Hutta")
+    PYKE = autodoc(description="A secretive, spice-dealing alien from Oba Diah", display_name="Pyke (Oba Diah)")
+
+
 class TestAutodoc:
     def test_autodoc_value(self):
         """
         Test that autodoc enum members still have the correct auto-generated value
         """
-        assert DocEnum.JAWA.value == "JAWA"
-        assert DocEnum.EWOK.value == "EWOK"
-        assert DocEnum.HUTT.value == "HUTT"
-        assert DocEnum.PYKE.value == "PYKE"
-
-    def test_autodoc_description(self):
-        """
-        Test that autodoc enum members have the correct description
-        """
-        assert DocEnum.JAWA.description == "A small, rodent-like alien from Tatooine"
-        assert DocEnum.EWOK.description == "A furry, diminutive alien from the forest moon of Endor"
-        assert DocEnum.HUTT.description == "A large, slug-like alien from Nal Hutta"
-        assert DocEnum.PYKE.description == "A secretive, spice-dealing alien from Oba Diah"
+        assert PositionalDescriptionEnum.JAWA.value == "JAWA"
+        assert PositionalDescriptionEnum.EWOK.value == "EWOK"
+        assert PositionalDescriptionEnum.HUTT.value == "HUTT"
+        assert PositionalDescriptionEnum.PYKE.value == "PYKE"
 
     def test_autodoc_str(self):
         """
         Test that autodoc enum members can be properly cast to strings
         """
-        assert str(DocEnum.JAWA) == "JAWA"
-        assert str(DocEnum.EWOK) == "EWOK"
-        assert str(DocEnum.HUTT) == "HUTT"
-        assert str(DocEnum.PYKE) == "PYKE"
+        assert str(PositionalDescriptionEnum.JAWA) == "JAWA"
+        assert str(PositionalDescriptionEnum.EWOK) == "EWOK"
+        assert str(PositionalDescriptionEnum.HUTT) == "HUTT"
+        assert str(PositionalDescriptionEnum.PYKE) == "PYKE"
+
+    def test_autodoc_positional_description(self):
+        """
+        Test that autodoc enum members have the correct description
+        """
+        assert PositionalDescriptionEnum.JAWA.description == "A small, rodent-like alien from Tatooine"
+        assert PositionalDescriptionEnum.EWOK.description == "A furry, diminutive alien from the forest moon of Endor"
+        assert PositionalDescriptionEnum.HUTT.description == "A large, slug-like alien from Nal Hutta"
+        assert PositionalDescriptionEnum.PYKE.description == "A secretive, spice-dealing alien from Oba Diah"
+
+    def test_autodoc_kwarg_docs(self):
+        """
+        Test that autodoc enum members have the correct description
+        """
+        assert KwargDocsEnum.JAWA.description == "A small, rodent-like alien from Tatooine"
+        assert KwargDocsEnum.EWOK.description == "A furry, diminutive alien from the forest moon of Endor"
+        assert KwargDocsEnum.HUTT.description == "A large, slug-like alien from Nal Hutta"
+        assert KwargDocsEnum.PYKE.description == "A secretive, spice-dealing alien from Oba Diah"
+
+        assert KwargDocsEnum.JAWA.display_name == "Jawa (Tatooine)"
+        assert KwargDocsEnum.EWOK.display_name == "Ewok (Endor)"
+        assert KwargDocsEnum.HUTT.display_name == "Hutt (Nal Hutta)"
+        assert KwargDocsEnum.PYKE.display_name == "Pyke (Oba Diah)"
 
     def test_mixed_auto_and_autodoc(self):
         """
@@ -133,28 +155,27 @@ class TestAutodoc:
         """
         assert MixedEnum.JAWA.value == "JAWA"
         assert MixedEnum.JAWA.description == "A small, rodent-like alien from Tatooine"
+        assert MixedEnum.JAWA.display_name == "JAWA"
 
         assert MixedEnum.EWOK.value == "EWOK"
         assert MixedEnum.EWOK.description is None
+        assert MixedEnum.EWOK.display_name == "EWOK"
 
         assert MixedEnum.HUTT.value == "HUTT"
         assert MixedEnum.HUTT.description == "A large, slug-like alien from Nal Hutta"
+        assert MixedEnum.HUTT.display_name == "HUTT"
+
+        assert MixedEnum.PYKE.value == "PYKE"
+        assert MixedEnum.PYKE.description == "A secretive, spice-dealing alien from Oba Diah"
+        assert MixedEnum.PYKE.display_name == "Pyke (Oba Diah)"
 
     def test_autodoc_iteration(self):
         """
         Test that enums with autodoc can be iterated over
         """
-        members = list(DocEnum)
+        members = list(PositionalDescriptionEnum)
         assert len(members) == 4
-        assert DocEnum.JAWA in members
-        assert DocEnum.EWOK in members
-        assert DocEnum.HUTT in members
-        assert DocEnum.PYKE in members
-
-    def test_description_on_auto_members(self):
-        """
-        Test that members created with auto() return None for description
-        """
-        assert DummyEnum.JAWA.description is None
-        assert DummyEnum.EWOK.description is None
-        assert DummyEnum.HUTT.description is None
+        assert PositionalDescriptionEnum.JAWA in members
+        assert PositionalDescriptionEnum.EWOK in members
+        assert PositionalDescriptionEnum.HUTT in members
+        assert PositionalDescriptionEnum.PYKE in members

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,4 +1,4 @@
-from auto_name_enum import AutoNameEnum, auto, LowerCaseMixin, TitleCaseMixin
+from auto_name_enum import AutoNameEnum, auto, autodoc, LowerCaseMixin, TitleCaseMixin
 
 
 class LowerEnum(AutoNameEnum, LowerCaseMixin):
@@ -7,11 +7,28 @@ class LowerEnum(AutoNameEnum, LowerCaseMixin):
     HUTT = auto()
 
 
+class LowerAutoDocEnum(AutoNameEnum, LowerCaseMixin):
+    JAWA = autodoc(description="A small, rodent-like alien from Tatooine", display_name="Jawa (Tatooine)")
+    EWOK = autodoc(description="A furry, diminutive alien from the forest moon of Endor", display_name="Ewok (Endor)")
+    HUTT = autodoc(description="A large, slug-like alien from Nal Hutta", display_name="Hutt (Nal Hutta)")
+
+
 class TestLowerCaseMixin:
     def test_auto(self):
         assert LowerEnum.JAWA.value == "jawa"
         assert LowerEnum.EWOK.value == "ewok"
         assert LowerEnum.HUTT.value == "hutt"
+
+    def test_autodoc(self):
+        assert LowerAutoDocEnum.JAWA.value == "jawa"
+        assert LowerAutoDocEnum.JAWA.description == "A small, rodent-like alien from Tatooine"
+        assert LowerAutoDocEnum.JAWA.display_name == "Jawa (Tatooine)"
+        assert LowerAutoDocEnum.EWOK.value == "ewok"
+        assert LowerAutoDocEnum.EWOK.description == "A furry, diminutive alien from the forest moon of Endor"
+        assert LowerAutoDocEnum.EWOK.display_name == "Ewok (Endor)"
+        assert LowerAutoDocEnum.HUTT.value == "hutt"
+        assert LowerAutoDocEnum.HUTT.description == "A large, slug-like alien from Nal Hutta"
+        assert LowerAutoDocEnum.HUTT.display_name == "Hutt (Nal Hutta)"
 
 
 class TitleEnum(AutoNameEnum, TitleCaseMixin):
@@ -20,8 +37,25 @@ class TitleEnum(AutoNameEnum, TitleCaseMixin):
     HUTT = auto()
 
 
+class TitleAutoDocEnum(AutoNameEnum, TitleCaseMixin):
+    JAWA = autodoc(description="A small, rodent-like alien from Tatooine", display_name="Jawa (Tatooine)")
+    EWOK = autodoc(description="A furry, diminutive alien from the forest moon of Endor", display_name="Ewok (Endor)")
+    HUTT = autodoc(description="A large, slug-like alien from Nal Hutta", display_name="Hutt (Nal Hutta)")
+
+
 class TestTitleCaseMixin:
     def test_auto(self):
         assert TitleEnum.JAWA.value == "Jawa"
         assert TitleEnum.EWOK.value == "Ewok"
         assert TitleEnum.HUTT.value == "Hutt"
+
+    def test_autodoc(self):
+        assert TitleAutoDocEnum.JAWA.value == "Jawa"
+        assert TitleAutoDocEnum.JAWA.description == "A small, rodent-like alien from Tatooine"
+        assert TitleAutoDocEnum.JAWA.display_name == "Jawa (Tatooine)"
+        assert TitleAutoDocEnum.EWOK.value == "Ewok"
+        assert TitleAutoDocEnum.EWOK.description == "A furry, diminutive alien from the forest moon of Endor"
+        assert TitleAutoDocEnum.EWOK.display_name == "Ewok (Endor)"
+        assert TitleAutoDocEnum.HUTT.value == "Hutt"
+        assert TitleAutoDocEnum.HUTT.description == "A large, slug-like alien from Nal Hutta"
+        assert TitleAutoDocEnum.HUTT.display_name == "Hutt (Nal Hutta)"


### PR DESCRIPTION
This adds the `display_name` kwarg to autodoc() capability.

Also fixed issue with mixins not respecting autodoc.